### PR TITLE
Removes left-over console.log

### DIFF
--- a/test/json_test.js
+++ b/test/json_test.js
@@ -3,8 +3,6 @@ import json from '../src/json'
 import sampleJson from './utilities/sampleJson.json'
 
 describe('json()', () => {
-  console.log(json, sampleJson)
-
   it('Should return a path to 4chan.', () => {
     expect(json(sampleJson, '4chan')).to.equal('favoriteSites -> 1')
   })


### PR DESCRIPTION
console.log statement left over in mocha test for json_test.js
removed it so that `npm run lint` wouldn't throw error