### PR TITLE
ESLint fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,13 +2,15 @@
     "env": {
         "es6": true,
         "node": true,
-        "mocha": true
+        "mocha": true,
+        "browser": true
     },
     "extends": "eslint:recommended",
     "parserOptions": {
         "sourceType": "module"
     },
     "rules": {
+        "no-console": 0,
         "indent": [
             "error",
             2

--- a/src/eslint-false-positive-test.js
+++ b/src/eslint-false-positive-test.js
@@ -1,0 +1,7 @@
+function lintError() {
+  console.log("ESLINT says: Don't ever use double quotes")
+  console.log('This is because ESLint outputs blank if there\'s no errors')
+  console.log('This way, you see some errors, and know it\'s not just breaking')
+}
+
+lintError()

--- a/src/gate.js
+++ b/src/gate.js
@@ -12,16 +12,16 @@ function gate(instructions) {
       if(state.remoteWillStop) {
         state.remoteWillStop = false
         state.currentState = {
-          "CLOSING": 'STOPPED_WHILE_CLOSING',
-          "OPENING": 'STOPPED_WHILE_OPENING'
+          'CLOSING': 'STOPPED_WHILE_CLOSING',
+          'OPENING': 'STOPPED_WHILE_OPENING'
         }[state.currentState]
         state.listOfOutput.push('Gate: '+state.currentState)
         state.nextDirection = state.nextDirection === 'CLOSED' ? 'OPEN' : 'CLOSED'
       } else {
         state.remoteWillStop = true
         state.currentState = {
-          "OPEN": 'OPENING',
-          "CLOSED": 'CLOSING'
+          'OPEN': 'OPENING',
+          'CLOSED': 'CLOSING'
         }[state.nextDirection]
         state.listOfOutput.push('Gate: '+state.currentState)
       }

--- a/src/guessTheNumber.js
+++ b/src/guessTheNumber.js
@@ -4,7 +4,6 @@ const MAX = 100
 
 function guessTheNumber() {
   let theNumber = Math.floor((Math.random() * 100)) + 1
-  let numOfGuesses = 0
 
   const rl = readline.createInterface({
     input: process.stdin,
@@ -12,7 +11,6 @@ function guessTheNumber() {
   })
 
   const recurse = () => {
-    numOfGuesses++
     rl.question(`Guess a number between ${MIN} and ${MAX}\n`, (answer) => {
       if(answer < theNumber) {
         console.log(`You guessed too low. The number was ${theNumber} and you gussed ${answer}`)

--- a/src/lair.js
+++ b/src/lair.js
@@ -9,19 +9,17 @@ function factorial(operand) {
 function lair(operand) {
   let testNumber = 1
   const MAX_ITERATIONS = 103 // The highest number Spotlight Search will attempt to go to.
-  while(true) {
+  while(testNumber <= MAX_ITERATIONS + 1) {
     let result = factorial(testNumber)
     if(result === operand) {
       return --testNumber
     } else if(result > operand) {
       return 'NONE'
-    } else if(testNumber > MAX_ITERATIONS) {
+    } else if(testNumber >= MAX_ITERATIONS) {
       return 'EXCEEDED MAX ITERATIONS'
     }
     testNumber++
   }
-
-  return 'NONE'
 }
 
 

--- a/src/playit/main.js
+++ b/src/playit/main.js
@@ -1,25 +1,9 @@
-/*
-link gain to oscillator with tone
-use set interval for time to play
-use start button and stop button
-clear interval with stop button
-
-how to connect gain to oscillator - gain gives it volume
-without gain there is no volume being sent.
-
-*/
+'use strict'
 
 const BPM = 120 // Standard for classical music according to here: https://music.stackexchange.com/questions/4525/list-of-average-genre-tempo-bpm-levels
 const beatsPerMinuteToMillisecondsPerBeat = (bpm, notesPerMeasure) => ((bpm/60)*(1000/notesPerMeasure))
-//  Beats   minutes   milliseconds   
-// ------ x ------- x ------------ x ?
-// minute   second      seconds   
 
 document.addEventListener('DOMContentLoaded', () => {
-  // const audioNode = new AudioContext()
-  // const oscillator = audioNode.createOscillator()
-  // oscillator.connect(audioNode.destination)
-
   let interval
   let pianoScale = {
     'startNote': 'C',
@@ -58,7 +42,6 @@ document.addEventListener('DOMContentLoaded', () => {
   })
   document.getElementById('stop').addEventListener('click', () => {
     oscillator.stop()
-    delete oscillator
     clearInterval(interval)
   })
   document.getElementById('piano').addEventListener('click', () => {


### PR DESCRIPTION
- Adds false positive file to force ESLint to fail
  - without this, eslint just returns blank and there's
  no way to know if it broke, didn't run, or all is well.
- npm run lint seems to return node error, but linter still
runs just fine. You can also install eslint globally then
simply run `eslint ./` to avoid the error